### PR TITLE
update `TryToAnother` parameters in documentation

### DIFF
--- a/src/EnumConverter/EnumConverter.cs
+++ b/src/EnumConverter/EnumConverter.cs
@@ -10,8 +10,8 @@ namespace EnumConverterLibrary
         /// <summary>
         /// Convert <paramref name="enumValue"/> to <typeparamref name="TAnotherEnum"/>.
         /// </summary>
-        /// <typeparam name="TAnotherEnum">Enum that we want to get after convert.</typeparam>
-        /// <param name="enumValue">Input enum we want to convert to <typeparamref name="TAnotherEnum"/>.</param>
+        /// <typeparam name="TAnotherEnum">Enum that we want try to get after convert.</typeparam>
+        /// <param name="enumValue">Input enum we want try to convert to <typeparamref name="TAnotherEnum"/>.</param>
         /// <param name="ignoreCase">Ignore or regard case.</param>
         /// <exception cref="ArgumentNullException"/>
         /// <exception cref="ArgumentException"/>
@@ -27,8 +27,8 @@ namespace EnumConverterLibrary
         /// Convert <paramref name="enumValue"/> to <typeparamref name="TAnotherEnum"/>.
         /// </summary>
         /// <remarks>ignoreCase = true.</remarks>
-        /// <typeparam name="TAnotherEnum">Enum that we want to get after convert.</typeparam>
-        /// <param name="enumValue">Input enum we want to convert to <typeparamref name="TAnotherEnum"/>.</param>
+        /// <typeparam name="TAnotherEnum">Enum that we want try to get after convert.</typeparam>
+        /// <param name="enumValue">Input enum we want try to convert to <typeparamref name="TAnotherEnum"/>.</param>
         /// <exception cref="ArgumentNullException"/>
         /// <exception cref="ArgumentException"/>
         /// <exception cref="OverflowException"/>
@@ -42,8 +42,8 @@ namespace EnumConverterLibrary
         /// <summary>
         /// Try convert <paramref name="enumValue"/> to <typeparamref name="TAnotherEnum"/>.
         /// </summary>
-        /// <typeparam name="TAnotherEnum">Enum that we want to get after convert.</typeparam>
-        /// <param name="enumValue">Input enum we want to convert to <typeparamref name="TAnotherEnum"/>.</param>
+        /// <typeparam name="TAnotherEnum">Enum that we want try to get after convert.</typeparam>
+        /// <param name="enumValue">Input enum we want try to convert to <typeparamref name="TAnotherEnum"/>.</param>
         /// <param name="ignoreCase">Ignore or regard case.</param>
         /// <param name="anotherEnum"><typeparamref name="TAnotherEnum"/> or default of <typeparamref name="TAnotherEnum"/>.</param>
         /// <exception cref="ArgumentException"/>
@@ -58,8 +58,8 @@ namespace EnumConverterLibrary
         /// Try convert <paramref name="enumValue"/> to <typeparamref name="TAnotherEnum"/>.
         /// </summary>
         /// <remarks>ignoreCase = true.</remarks>
-        /// <typeparam name="TAnotherEnum">Enum that we want to get after convert.</typeparam>
-        /// <param name="enumValue">Input enum we want to convert to <typeparamref name="TAnotherEnum"/>.</param>
+        /// <typeparam name="TAnotherEnum">Enum that we want try to get after convert.</typeparam>
+        /// <param name="enumValue">Input enum we want try to convert to <typeparamref name="TAnotherEnum"/>.</param>
         /// <param name="anotherEnum"><typeparamref name="TAnotherEnum"/> or default of <typeparamref name="TAnotherEnum"/>.</param>
         /// <exception cref="ArgumentException"/>
         /// <returns>true if the <paramref name="enumValue"/> parameter was converted successfully; otherwise, false.</returns>
@@ -73,8 +73,8 @@ namespace EnumConverterLibrary
         /// Convert <paramref name="enumValue"/> to <typeparamref name="TAnotherEnum"/> or default value of <typeparamref name="TAnotherEnum"/> if not possible.
         /// </summary>
         /// <remarks>ignoreCase = true.</remarks>
-        /// <typeparam name="TAnotherEnum">Enum that we want to get after convert.</typeparam>
-        /// <param name="enumValue">Input enum we want to convert to <typeparamref name="TAnotherEnum"/>.</param>
+        /// <typeparam name="TAnotherEnum">Enum that we want try to get after convert.</typeparam>
+        /// <param name="enumValue">Input enum we want try to convert to <typeparamref name="TAnotherEnum"/>.</param>
         /// <exception cref="ArgumentException"/>
         /// <returns><typeparamref name="TAnotherEnum"/> or default value of <typeparamref name="TAnotherEnum"/> if not possible to convert.</returns>
         public static TAnotherEnum ToAnotherOrDefault<TAnotherEnum>(this Enum enumValue)
@@ -86,8 +86,8 @@ namespace EnumConverterLibrary
         /// <summary>
         /// Convert <paramref name="enumValue"/> to <typeparamref name="TAnotherEnum"/> or default value of <typeparamref name="TAnotherEnum"/> if not possible.
         /// </summary>
-        /// <typeparam name="TAnotherEnum">Enum that we want to get after convert.</typeparam>
-        /// <param name="enumValue">Input enum we want to convert to <typeparamref name="TAnotherEnum"/>.</param>
+        /// <typeparam name="TAnotherEnum">Enum that we want try to get after convert.</typeparam>
+        /// <param name="enumValue">Input enum we want try to convert to <typeparamref name="TAnotherEnum"/>.</param>
         /// <param name="ignoreCase">Ignore or regard case.</param>
         /// <exception cref="ArgumentException"/>
         /// <returns><typeparamref name="TAnotherEnum"/> or default value of <typeparamref name="TAnotherEnum"/> if not possible to convert.</returns>

--- a/src/EnumConverter/EnumConverter.cs
+++ b/src/EnumConverter/EnumConverter.cs
@@ -10,8 +10,8 @@ namespace EnumConverterLibrary
         /// <summary>
         /// Convert <paramref name="enumValue"/> to <typeparamref name="TAnotherEnum"/>.
         /// </summary>
-        /// <typeparam name="TAnotherEnum">Enum that we want try to get after convert.</typeparam>
-        /// <param name="enumValue">Input enum we want try to convert to <typeparamref name="TAnotherEnum"/>.</param>
+        /// <typeparam name="TAnotherEnum">Enum that we want to get after convert.</typeparam>
+        /// <param name="enumValue">Input enum we want to convert to <typeparamref name="TAnotherEnum"/>.</param>
         /// <param name="ignoreCase">Ignore or regard case.</param>
         /// <exception cref="ArgumentNullException"/>
         /// <exception cref="ArgumentException"/>
@@ -27,8 +27,8 @@ namespace EnumConverterLibrary
         /// Convert <paramref name="enumValue"/> to <typeparamref name="TAnotherEnum"/>.
         /// </summary>
         /// <remarks>ignoreCase = true.</remarks>
-        /// <typeparam name="TAnotherEnum">Enum that we want try to get after convert.</typeparam>
-        /// <param name="enumValue">Input enum we want try to convert to <typeparamref name="TAnotherEnum"/>.</param>
+        /// <typeparam name="TAnotherEnum">Enum that we want to get after convert.</typeparam>
+        /// <param name="enumValue">Input enum we want to convert to <typeparamref name="TAnotherEnum"/>.</param>
         /// <exception cref="ArgumentNullException"/>
         /// <exception cref="ArgumentException"/>
         /// <exception cref="OverflowException"/>
@@ -73,8 +73,8 @@ namespace EnumConverterLibrary
         /// Convert <paramref name="enumValue"/> to <typeparamref name="TAnotherEnum"/> or default value of <typeparamref name="TAnotherEnum"/> if not possible.
         /// </summary>
         /// <remarks>ignoreCase = true.</remarks>
-        /// <typeparam name="TAnotherEnum">Enum that we want try to get after convert.</typeparam>
-        /// <param name="enumValue">Input enum we want try to convert to <typeparamref name="TAnotherEnum"/>.</param>
+        /// <typeparam name="TAnotherEnum">Enum that we want to get after convert.</typeparam>
+        /// <param name="enumValue">Input enum we want to convert to <typeparamref name="TAnotherEnum"/>.</param>
         /// <exception cref="ArgumentException"/>
         /// <returns><typeparamref name="TAnotherEnum"/> or default value of <typeparamref name="TAnotherEnum"/> if not possible to convert.</returns>
         public static TAnotherEnum ToAnotherOrDefault<TAnotherEnum>(this Enum enumValue)
@@ -86,8 +86,8 @@ namespace EnumConverterLibrary
         /// <summary>
         /// Convert <paramref name="enumValue"/> to <typeparamref name="TAnotherEnum"/> or default value of <typeparamref name="TAnotherEnum"/> if not possible.
         /// </summary>
-        /// <typeparam name="TAnotherEnum">Enum that we want try to get after convert.</typeparam>
-        /// <param name="enumValue">Input enum we want try to convert to <typeparamref name="TAnotherEnum"/>.</param>
+        /// <typeparam name="TAnotherEnum">Enum that we want to get after convert.</typeparam>
+        /// <param name="enumValue">Input enum we want to convert to <typeparamref name="TAnotherEnum"/>.</param>
         /// <param name="ignoreCase">Ignore or regard case.</param>
         /// <exception cref="ArgumentException"/>
         /// <returns><typeparamref name="TAnotherEnum"/> or default value of <typeparamref name="TAnotherEnum"/> if not possible to convert.</returns>


### PR DESCRIPTION
This fixes #33.

I added the word `try` to the the following sentences, anywhere that they appeared in the documentation:
- "Enum that we want _try_ to get after convert."
- "Input enum we want _try_ to convert to <typeparamref name="TAnotherEnum"/>."

Let me know if I missed anything. 

Also, if you could add the label `hacktoberfest-accepted` to this PR, I would greatly appreciate it :)